### PR TITLE
Added option to rename the project from UI - like alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
 					"light": "media/arrow_down_light.svg",
 					"dark": "media/arrow_down_light.svg"
 				}
+			},
+			{
+				"command": "lsio-projects.renameProject",
+				"title": "Rename Project"
 			}
 		],
 		"viewsContainers": {
@@ -104,6 +108,10 @@
 				},
 				{
 					"command": "lsio-projects.openProject",
+					"when": "view == projects"
+				},
+				{
+					"command": "lsio-projects.renameProject",
 					"when": "view == projects"
 				}
 			]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,9 +41,9 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 	vscode.commands.registerCommand('lsio-projects.renameProject', async (project: Project) => {
 		const newName = await vscode.window.showInputBox({
-			placeHolder: project.label,
-			prompt: "New name"
-			// value: ""
+			placeHolder: "Provide a name",
+			prompt: "New name",
+			value: project.label
 		}) || "";
 		if(newName === ""){
 			vscode.window.showErrorMessage('Please provide some name for this action');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,18 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 		vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(project.path));
 	});
+	vscode.commands.registerCommand('lsio-projects.renameProject', async (project: Project) => {
+		const newName = await vscode.window.showInputBox({
+			placeHolder: project.label,
+			prompt: "New name"
+			// value: ""
+		}) || "";
+		if(newName === ""){
+			vscode.window.showErrorMessage('Please provide some name for this action');
+		} else {
+			projectsProvider.renameProject(project, newName);
+		}
+	});
 }
 
 // this method is called when your extension is deactivated

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -34,6 +34,11 @@ export class ProjectsNodeProvider implements vscode.TreeDataProvider<Project> {
                 command: 'lsio-projects.openProject',
                 title: '',
                 arguments: [p]
+            },
+            {
+                command: 'lsio-projects.renameProject',
+                title: '',
+                arguments: [p]
             }
         ));
 
@@ -59,6 +64,18 @@ export class ProjectsNodeProvider implements vscode.TreeDataProvider<Project> {
             return;
         }
         const newProjectConfigs = [...projectConfigs, {name, path}];
+        config.update("paths", newProjectConfigs, vscode.ConfigurationTarget.Global).then(() => this.refresh());
+    }
+
+    public renameProject(project: Project, newName: string) {
+        const config = vscode.workspace.getConfiguration("lsio-projects");
+        const projectConfigs: ProjectConfig[] = (config.get("paths") || []);
+        const newProjectConfigs = projectConfigs.map((p) => {
+            if(p.path == project.path) {
+                p.name = newName;
+            }
+            return p;
+        });
         config.update("paths", newProjectConfigs, vscode.ConfigurationTarget.Global).then(() => this.refresh());
     }
 
@@ -97,7 +114,8 @@ export class Project extends vscode.TreeItem {
 		public readonly label: string,
         public readonly path: string,
 		public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-		public readonly command?: vscode.Command
+		public readonly command?: vscode.Command,
+		public readonly command2?: vscode.Command
 	) {
 		super(label, collapsibleState);
 


### PR DESCRIPTION
Hey Lachlansleight


I found your extension useful.

I work in an org and the folder names are quite generic so, I liked to have an alias for the folders (Projects).
So, I added an option for that. Hope others also might find it useful.
If you feel the same, feel free to review and merge my changes to your repo.

Thanks and Regards,
Caleb Hillary